### PR TITLE
fixed: skip validation password matching on reset password

### DIFF
--- a/pages/auth/reset-password.tsx
+++ b/pages/auth/reset-password.tsx
@@ -14,10 +14,10 @@ export default function ResetPasswordPage() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (e.target.elements.password.value !== e.target.elements.confirmPassword.value) {
-      setError("Les mots de passe ne correspondent pas");
-      return;
-    }
+      if (emailVerified && (e.target.elements.password.value !== e.target.elements.confirmPassword.value)) {
+        setError("Les mots de passe ne correspondent pas");
+        return;
+      } 
     try {
       const resetedPassword = await resetPassword(token, e.target.elements.password.value);
 


### PR DESCRIPTION
Il y avait une erreur qui empechait les utilisateurs de réinitialiser le mot de passe car la validation de correspondance de mot de passe échouait 